### PR TITLE
IP ACL Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ cp env.example .env
 - `DATABRICKS_HOST`: Your Databricks workspace URL (has default)
 - `SAMPLE_QUESTIONS`: Semicolon-delimited list of sample questions to show users when they first log in. Customize these for your specific Genie space and use case (default: generic questions about data availability)
 - `ADMIN_CONTACT_EMAIL`: Email address displayed to users in the info command for support inquiries (default: admin@company.com)
-- `TEAMS_APP_PACKAGE_NAME`: Teams app package name (has default)
-- `TEAMS_APP_VERSION`: Teams app version (has default)
 - `ENABLE_FEEDBACK_CARDS`: Enable/disable feedback collection (default: True)
 - `ENABLE_GENIE_FEEDBACK_API`: Enable/disable sending feedback to Databricks Genie API (default: True)
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -120,7 +120,7 @@ No data available.
 Source IP address: X.X.X.X is blocked by Databricks IP ACL for workspace
 ```
 
-**Cause:** Your Azure App Service's outbound IP address is blocked by Databricks IP Access Lists (ACLs)
+**Cause:** Your Azure App Service's outbound IP address is blocked by Databricks Account IP Access Lists (ACLs)
 
 **Solutions:**
 
@@ -131,20 +131,22 @@ Source IP address: X.X.X.X is blocked by Databricks IP ACL for workspace
    - Copy all the IP addresses listed (there may be several)
    - Example: `198.51.100.10, 198.51.100.20, 198.51.100.30`
 
-2. **Add IPs to Databricks Allow List (Web UI Method):**
-   - Go to your Databricks workspace
-   - Navigate to **Admin Settings** → **IP Access Lists**
-   - Click **Add** to create a new IP access list entry
+2. **Add IPs to Databricks Account Allow List (Web UI Method):**
+   - Log into your **Databricks Account Console** (not workspace)
+   - In the sidebar, click **Settings**
+   - Navigate to **Security and Compliance** tab
+   - Click **IP Access List**
+   - Click **Add rule**
    - Add each Azure App Service outbound IP address
    - Label it clearly (e.g., "teams-genie-bot")
    - Select **ALLOW** as the list type
-   - Click **Add** to save
+   - Click **Add rule** to save
 
-   **For detailed instructions**, see: [Configure IP access lists for workspaces](https://docs.databricks.com/aws/en/security/network/front-end/ip-access-list-account)
+   **For detailed instructions**, see: [Configure IP access lists for the account console](https://docs.databricks.com/aws/en/security/network/front-end/ip-access-list-account)
 
-3. **Add IPs to Databricks Allow List (CLI Method):**
+3. **Add IPs to Databricks Account Allow List (CLI Method):**
    
-   If you prefer using the Databricks CLI, you can add IPs programmatically:
+   If you prefer using the Databricks CLI, you can add IPs programmatically to your Account:
 
    ```bash
    databricks ip-access-lists create --json '{
@@ -160,6 +162,8 @@ Source IP address: X.X.X.X is blocked by Databricks IP ACL for workspace
 
    Replace the IP addresses with your actual Azure App Service outbound IPs. The `/32` suffix means a single IP address.
 
+   **Note**: Make sure your CLI is configured to use account-level authentication.
+
    **For CLI documentation**, see: [Databricks CLI IP Access Lists Commands](https://docs.databricks.com/aws/en/dev-tools/cli/reference/ip-access-lists-commands)
 
 4. **Alternative: Use Azure VNet Integration** (Advanced):
@@ -168,15 +172,16 @@ Source IP address: X.X.X.X is blocked by Databricks IP ACL for workspace
    - This provides a more secure, stable IP address
 
 5. **Test the Connection:**
-   - After adding IPs to the allow list, wait a few minutes for changes to take effect
+   - After adding IPs to the Account allow list, wait a few minutes for changes to take effect
    - Try querying the bot again
    - Check Azure App Service logs to confirm the 403 error is gone
    - If still blocked, verify the IP in the error log matches the IPs you added
 
 **Important Notes:**
+- **Account vs Workspace**: This error is at the **Account level**, not workspace level. Make sure you're adding IPs in the Account Console, not workspace settings
 - **IP Changes**: Azure App Service outbound IPs can change during scaling or updates
 - **Production Recommendation**: Consider using a static outbound IP with Azure NAT Gateway for production deployments
-- **Documentation**: Document all IPs added to Databricks ACL for future reference
+- **Documentation**: Document all IPs added to Databricks Account ACL for future reference
 - **Maximum IPs**: Databricks supports a maximum of 1000 IP/CIDR values across all allow and block lists
 - **Verification**: Always verify the IP in the error log matches the IPs you added to the allow list
 

--- a/app.py
+++ b/app.py
@@ -222,7 +222,25 @@ async def ask_genie(
 
         return json.dumps({"message": message_content.content}), conversation_id, initial_message.message_id
     except Exception as e:
-        logger.error(f"Error in ask_genie for user {user_session.get_display_name()}: {str(e)}")
+        error_str = str(e)
+        logger.error(f"Error in ask_genie for user {user_session.get_display_name()}: {error_str}")
+        
+        # Check for IP ACL blocking (403 Forbidden)
+        if "403" in error_str and ("IP ACL" in error_str or "blocked" in error_str.lower()):
+            logger.error(f"IP ACL blocking detected: {error_str}")
+            return (
+                json.dumps({
+                    "error": "⚠️ **IP Access Blocked**\n\n"
+                            "The bot's IP address is blocked by Databricks IP Access Control Lists (ACLs).\n\n"
+                            "**Administrator Action Required:**\n"
+                            "Please check the TROUBLESHOOTING.md documentation for instructions on adding "
+                            "the bot's IP address to your Databricks workspace IP allow list."
+                }),
+                conversation_id,
+                None,
+            )
+        
+        # Generic error for other cases
         return (
             json.dumps({"error": "An error occurred while processing your request."}),
             conversation_id,
@@ -258,6 +276,8 @@ def process_query_results(answer_json: Dict) -> str:
                 response += "| " + " | ".join(formatted_row) + " |\n"
         else:
             response += f"Unexpected column format: {columns}\n\n"
+    elif "error" in answer_json:
+        response += f"{answer_json['error']}\n\n"
     elif "message" in answer_json:
         response += f"{answer_json['message']}\n\n"
     else:

--- a/app.py
+++ b/app.py
@@ -222,12 +222,13 @@ async def ask_genie(
 
         return json.dumps({"message": message_content.content}), conversation_id, initial_message.message_id
     except Exception as e:
-        error_str = str(e)
-        logger.error(f"Error in ask_genie for user {user_session.get_display_name()}: {error_str}")
+        error_str = str(e).lower()  # Convert to lowercase for case-insensitive matching
+        error_original = str(e)  # Keep original for logging
+        logger.error(f"Error in ask_genie for user {user_session.get_display_name()}: {error_original}")
         
-        # Check for IP ACL blocking (403 Forbidden)
-        if "403" in error_str and ("IP ACL" in error_str or "blocked" in error_str.lower()):
-            logger.error(f"IP ACL blocking detected: {error_str}")
+        # Check for IP ACL blocking (403 Forbidden with IP ACL mention)
+        if ("403" in error_str or "forbidden" in error_str) and ("ip acl" in error_str or ("blocked" in error_str and "ip address" in error_str)):
+            logger.error(f"IP ACL blocking detected: {error_original}")
             return (
                 json.dumps({
                     "error": "⚠️ **IP Access Blocked**\n\n"

--- a/app.py
+++ b/app.py
@@ -226,8 +226,9 @@ async def ask_genie(
         error_original = str(e)  # Keep original for logging
         logger.error(f"Error in ask_genie for user {user_session.get_display_name()}: {error_original}")
         
-        # Check for IP ACL blocking (403 Forbidden with IP ACL mention)
-        if ("403" in error_str or "forbidden" in error_str) and ("ip acl" in error_str or ("blocked" in error_str and "ip address" in error_str)):
+        # Check for IP ACL blocking - look for "blocked" + "ip acl" pattern
+        # Error message format: "Source IP address: X.X.X.X is blocked by Databricks IP ACL for workspace"
+        if "ip acl" in error_str and "blocked" in error_str:
             logger.error(f"IP ACL blocking detected: {error_original}")
             return (
                 json.dumps({

--- a/app.py
+++ b/app.py
@@ -233,10 +233,10 @@ async def ask_genie(
             return (
                 json.dumps({
                     "error": "⚠️ **IP Access Blocked**\n\n"
-                            "The bot's IP address is blocked by Databricks IP Access Control Lists (ACLs).\n\n"
+                            "The bot's IP address is blocked by Databricks Account IP Access Control Lists (ACLs).\n\n"
                             "**Administrator Action Required:**\n"
                             "Please check the TROUBLESHOOTING.md documentation for instructions on adding "
-                            "the bot's IP address to your Databricks workspace IP allow list."
+                            "the bot's IP address to your Databricks Account IP allow list."
                 }),
                 conversation_id,
                 None,


### PR DESCRIPTION
Provides more context to admins and users when IP ACLs are blocking their Genie bot. Also providing sample code in the TROUBLESHOOTING.md to resolve